### PR TITLE
 Modified the redis dependency version constraint to be >=0.28.0,<0.29.0 instead of just >=0.28.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Cargo.lock
 
 # Remove .idea folder:
 *.idea
+
+# Remove .DS_Store file:
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## ✨ v0.5.4 [Unreleased]
+
+### Changed:
+
+- 🚀 Modified the Redis dependency version constraint to be >=0.28.0,<0.29.0 instead of just >=0.28.0. By [@JMTamayo](https://github.com/JMTamayo).
+
 ## ✨ v0.5.3 [2025-01-27]
 
 ### Changed:

--- a/redsumer-rs/Cargo.toml
+++ b/redsumer-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redsumer"
 description = "Lightweight implementation of Redis Streams for Rust"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 license-file = "../LICENSE"
 readme = "../README.md"
@@ -13,7 +13,7 @@ categories = ["database-implementations"]
 authors = ["Juan Manuel Tamayo <jmtamayog23@gmail.com>"]
 
 [dependencies]
-redis = { version = ">=0.28.0", features = ["streams"] }
+redis = { version = ">=0.28.0,<0.29.0", features = ["streams"] }
 tracing = { version = ">=0.1.40" }
 
 [dev-dependencies]


### PR DESCRIPTION
This pull request includes updates to the `redsumer` package in the `Cargo.toml` file. The most important changes include updating the package version and modifying the version constraint for the `redis` dependency.

Version updates:

* [`redsumer-rs/Cargo.toml`](diffhunk://#diff-8263ffd4fca01ca77c83a85e9a0e49d3cc4f58aee24d2118d93f02e2fd1d456aL4-R4): Updated the package version from `0.5.3` to `0.5.4`.

Dependency updates:

* [`redsumer-rs/Cargo.toml`](diffhunk://#diff-8263ffd4fca01ca77c83a85e9a0e49d3cc4f58aee24d2118d93f02e2fd1d456aL16-R16): Modified the `redis` dependency version constraint to be `>=0.28.0,<0.29.0` instead of just `>=0.28.0`.